### PR TITLE
Change not to display "git_user" segment when git user.name is not specified

### DIFF
--- a/src/segments/git_user.rs
+++ b/src/segments/git_user.rs
@@ -4,13 +4,16 @@ use crate::segments::{Segment, SegmentError};
 pub fn build_segment(context: &Context) -> Result<Option<Segment>, SegmentError> {
     let config = &context.config.git_user;
 
-    let repo = match &context.git_repo {
-        Some(repo) => repo,
+    let user = context
+        .git_repo
+        .as_ref()
+        .and_then(|repo| repo.config().ok())
+        .and_then(|config| config.get_string("user.name").ok());
+
+    let user = match user {
+        Some(user) => user,
         None => return Ok(None),
     };
-
-    let git_config = repo.config()?;
-    let user = git_config.get_string("user.name")?;
 
     Ok(Some(Segment {
         background: config.background,


### PR DESCRIPTION
```sh
(almel prompt $) git config --unset user.name
config value 'user.name' was not found; class=Config (7); code=NotFound (-3)
(almel prompt $)
```